### PR TITLE
Clean network handlers

### DIFF
--- a/forge/src/main/java/gg/chaldea/client/reset/packet/ClientReset.java
+++ b/forge/src/main/java/gg/chaldea/client/reset/packet/ClientReset.java
@@ -20,6 +20,7 @@ import net.minecraftforge.registries.GameData;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 
+import java.util.NoSuchElementException;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 import org.apache.commons.lang3.tuple.Pair;
@@ -97,6 +98,14 @@ public class ClientReset {
 
             // Clear
             Minecraft.getInstance().clearLevel(new DirtMessageScreen(new TranslationTextComponent("connect.negotiating")));
+            try {
+                context.getNetworkManager().channel().pipeline().remove("forge:forge_fixes");
+            } catch (NoSuchElementException ignored) {
+            }
+            try {
+                context.getNetworkManager().channel().pipeline().remove("forge:vanilla_filter");
+            } catch (NoSuchElementException ignored) {
+            }
 
             // Restore
             Minecraft.getInstance().setCurrentServer(serverData);


### PR DESCRIPTION
### Symptom
![bild](https://user-images.githubusercontent.com/52883522/202815093-c54e47eb-5ec0-4563-bf7c-017cf6f1ae86.png)


It throws an exception because the reset packet mod dosen't clean everything
The channel handlers are still present after resetting 


### Problem
_In handleLogin(ClientboundLoginPacket) at ClientPacketListener.java_
![bild](https://user-images.githubusercontent.com/52883522/202815202-7732b34f-51a5-4005-9545-7a4aba81c0c6.png)
Everything under here doesn't even get to run
Which may break stuff.